### PR TITLE
Add scan permissions to lambda to be able to start scans

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -183,6 +183,28 @@ data "aws_iam_policy_document" "geff_lambda_policy_doc" {
     }
   }
 
+  statement {
+    sid       = "EcrScanImages"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:ListTagsForResource",
+      "ecr:DescribeImageScanFindings",
+      "ecr:StartImageScan",
+    ]
+  }
+
   # Write to S3
   statement {
     sid       = "WriteToS3"


### PR DESCRIPTION
Support image scanning use case from lambda by adding scan image perms.